### PR TITLE
Patch/parse nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 _dates are in dd-mm-yyyy format_
 
+### 24-12-2017 VERSION 4.2.3
+
+- Loosened some Android label version ranges
+- `Browserino::Version` can now also parse floats float `1.1` equals major version 1, minor version 1, patch level 0
+
 ### 12-10-2017 VERSION 4.2.2
 
 - Added support for `high_sierra`

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ about their browser / OS versions.
         <li><a href="#table-of-contents">Table of Contents</a></li>
         <li><a href="#sources">Sources</a></li>
         <li><a href="#changelog">Changelog</a><ul>
+            <li><a href="#21-10-2018-version-441">21-10-2018 VERSION 4.4.1</a></li>
             <li><a href="#23-06-2018-version-440">23-06-2018 VERSION 4.4.0</a></li>
             <li><a href="#23-06-2018-version-430">23-06-2018 VERSION 4.3.0</a></li>
-            <li><a href="#24-12-2017-version-423">24-12-2017 VERSION 4.2.3</a></li>
         </ul></li>
         <li><a href="#installation">Installation</a></li>
         <li><a href="#rails--320">Rails (>= 3.2.0)</a><ul>
@@ -116,6 +116,10 @@ Many thanks to the creators and maintainers of the following sources of user age
 _dates are in dd-mm-yyyy format_
 older changes can be found in the [changelog](/projects/browserino/changelog/)
 
+### 21-10-2018 VERSION 4.4.1
+
+- Fix: `Browserino.parse` handles `nil` and `false` by converting them to an empty string
+
 ### 23-06-2018 VERSION 4.4.0
 
 - Update: Gem dependencies
@@ -157,11 +161,6 @@ older changes can be found in the [changelog](/projects/browserino/changelog/)
 
 - Add macOS `mojave` label
 - Add generic `android_*` labels for android versions `p` through `z`.
-
-### 24-12-2017 VERSION 4.2.3
-
-- Loosened some Android label version ranges
-- `Browserino::Version` can now also parse floats float `1.1` equals major version 1, minor version 1, patch level 0
 
 ## Installation
 
@@ -248,6 +247,8 @@ the `parse` method will **always** return a `Browserino::Client` object. This ob
 client = Browserino.parse ''
 client.is_a? Browserino::Client # => true
 ```
+
+Prior to version `4.4.1`, `Browserino.parse nil` or `Browserino.parse false` were invalid. As of `4.4.1` an empty user agent (`''`) is assumed when these values are used.
 
 ### Formatting
 

--- a/lib/browserino.rb
+++ b/lib/browserino.rb
@@ -17,6 +17,8 @@ require_relative 'browserino/definitions/missing_props'
 
 module Browserino
   def self.parse(uas, headers = nil)
+    uas = '' unless uas #stringify user agent before usage when nil or false
+
     uas = config.before_parse.reduce(uas) { |u, b| b.call u }
     config.matchers.each do |matcher|
       return analyze uas, matcher, headers if matcher.matches? uas

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -4,6 +4,10 @@ describe 'Browserino::Client' do
   client = Browserino.parse Library.random_user_agent
   client = Browserino.parse Library.random_user_agent until client.name
 
+  it 'converts nil to an empty string' do
+    expect(Browserino.parse(nil)).to be_instance_of Browserino::Client
+  end
+
   it 'always responds to missing' do
     expect(client.respond_to?(client.name)).to be true
   end


### PR DESCRIPTION
Fixes #1 by interperting values `nil` and `false` as an empty user-agent string (`''`).